### PR TITLE
feat: implement styles & allow pocket selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Simple web app that allows a user to browse their "pockets" and exchange currenc
 
 ## Scripts
 
-This is a [Next.js](https://nextjs.org/) project.
+This is a [Next.js](https://nextjs.org/) project, styled with [normalize.css](http://necolas.github.io/normalize.css/) and [terminal.css](https://terminalcss.xyz/).
 
 A local env file is required to access APIs. Create one with `cp .env .env.local` and add missing keys.
 

--- a/__tests__/__snapshots__/snapshots.tsx.snap
+++ b/__tests__/__snapshots__/snapshots.tsx.snap
@@ -2,82 +2,250 @@
 
 exports[`[Function Exchange] snapshot 1`] = `
 <div>
-  <form
-    id="exchange"
-    name="exchange"
+  <div
+    class="terminal-nav header"
   >
-    <label
-      for="from"
+    <div
+      class="terminal-logo"
     >
-      GBP
-    </label>
-    <input
-      id="from"
-      max="58.33"
-      min="0"
-      name="from"
-      required=""
-      step="0.01"
-      type="number"
-      value=""
-    />
-    <div>
-      You have £58.33
+      <div
+        class="logo terminal-prompt"
+      >
+        <a
+          class="no-style"
+          href="#"
+        >
+          currency-exchange
+        </a>
+      </div>
     </div>
-    <label
-      for="to"
+    <nav
+      class="terminal-menu"
     >
-      USD
-    </label>
-    <input
-      id="to"
-      max="25.51"
-      min="0"
-      name="to"
-      readonly=""
-      step="0.01"
-      tabindex="-1"
-      type="number"
-      value=""
-    />
-    <div>
-      You have $25.51
-    </div>
-    <pre>
-      <code>
+      <ul>
+        <li>
+          <a
+            class="menu-item active"
+            href="/exchange"
+          >
+            Exchange
+          </a>
+        </li>
+        <li>
+          <a
+            class="menu-item"
+            href="/"
+          >
+            About
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+  <div
+    class="container"
+  >
+    <form
+      id="exchange"
+      name="exchange"
+    >
+      <fieldset>
+        <legend>
+          Pockets
+        </legend>
+        <div
+          class="form-group"
+        >
+          <span
+            style="display: inline-flex;"
+          >
+            <label
+              for="from"
+              style="text-transform: capitalize;"
+            >
+              from: 
+            </label>
+            <a
+              class="pocket-currency-option"
+              role="button"
+            >
+              EUR
+            </a>
+            <a
+              class="pocket-currency-option active"
+              role="button"
+            >
+              GBP
+            </a>
+            <a
+              class="pocket-currency-option"
+              role="button"
+            >
+              USD
+            </a>
+          </span>
+          <input
+            id="from"
+            inputmode="decimal"
+            max="58.33"
+            min="0"
+            name="from"
+            pattern="[\\\\d\\\\.]*"
+            required=""
+            step="0.01"
+            type="number"
+            value=""
+          />
+          <div>
+            You have £58.33
+          </div>
+        </div>
+        <div
+          class="form-group"
+        >
+          <span
+            style="display: inline-flex;"
+          >
+            <label
+              for="to"
+              style="text-transform: capitalize;"
+            >
+              to: 
+            </label>
+            <a
+              class="pocket-currency-option"
+              role="button"
+            >
+              EUR
+            </a>
+            <a
+              class="pocket-currency-option"
+              role="button"
+            >
+              GBP
+            </a>
+            <a
+              class="pocket-currency-option active"
+              role="button"
+            >
+              USD
+            </a>
+          </span>
+          <input
+            id="to"
+            inputmode="decimal"
+            max="25.51"
+            min="0"
+            name="to"
+            pattern="[\\\\d\\\\.]*"
+            readonly=""
+            step="0.01"
+            tabindex="-1"
+            type="number"
+            value=""
+          />
+          <div>
+            You have $25.51
+          </div>
+        </div>
+        <div
+          class="form-group"
+          style="display: flex; justify-content: right;"
+        >
+          <button
+            class="btn btn-ghost"
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            class="btn btn-default"
+            type="submit"
+          >
+            Exchange
+          </button>
+        </div>
+      </fieldset>
+    </form>
+    <div
+      class="terminal-prompt borderless-box"
+    >
+      <span
+        class=""
+        style="white-space: pre-wrap;"
+      >
          
-      </code>
-    </pre>
-    <button
-      type="button"
-    >
-      Cancel
-    </button>
-    <button
-      type="submit"
-    >
-      Exchange
-    </button>
-  </form>
+      </span>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`[Function Home] snapshot 1`] = `
 <div>
-  <h3>
-    currency-exchange
-  </h3>
-  <pre>
-    <a
-      href="https://github.com/sombreroEnPuntas/currency-exchange"
-    >
-      Check the code on github!
-    </a>
-  </pre>
-  <a
-    href="/exchange"
+  <div
+    class="terminal-nav header"
   >
-    Exchange
-  </a>
+    <div
+      class="terminal-logo"
+    >
+      <div
+        class="logo terminal-prompt"
+      >
+        <a
+          class="no-style"
+          href="#"
+        >
+          currency-exchange
+        </a>
+      </div>
+    </div>
+    <nav
+      class="terminal-menu"
+    >
+      <ul>
+        <li>
+          <a
+            class="menu-item"
+            href="/exchange"
+          >
+            Exchange
+          </a>
+        </li>
+        <li>
+          <a
+            class="menu-item active"
+            href="/"
+          >
+            About
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+  <div
+    class="container"
+  >
+    <div
+      class="borderless-box"
+    >
+      <p>
+        To try the exchange app, go to &gt;&gt; 
+        <a
+          href="/exchange"
+        >
+          Exchange
+        </a>
+      </p>
+      <p>
+        Check the code on &gt;&gt; 
+        <a
+          href="https://github.com/sombreroEnPuntas/currency-exchange"
+        >
+          github!
+        </a>
+      </p>
+    </div>
+  </div>
 </div>
 `;

--- a/__tests__/snapshots.tsx
+++ b/__tests__/snapshots.tsx
@@ -5,16 +5,31 @@ import { render } from '@testing-library/react'
 import Exchange from '../pages/exchange'
 import Index from '../pages/index'
 
+// Deps
+import { useRouter } from 'next/router'
+
 // Utils
 import TestProvider from '../src/utils/TestProvider'
 import { ratesDataMock } from '../src/utils/mocks'
 
+// Mocks
+jest.mock('next/router')
+
+// Mock data
+const setMock = ({ pathname }) => {
+  ;(useRouter as jest.Mock).mockImplementation(() => ({
+    pathname,
+  }))
+}
+
 describe.each`
-  Page        | props
-  ${Exchange} | ${{ initialData: ratesDataMock }}
-  ${Index}    | ${{}}
-`('$Page.displayName', ({ Page, props }) => {
+  Page        | props                             | mocks
+  ${Exchange} | ${{ initialData: ratesDataMock }} | ${{ pathname: '/exchange' }}
+  ${Index}    | ${{}}                             | ${{ pathname: '/' }}
+`('$Page.displayName', ({ Page, props, mocks }) => {
   test('snapshot', () => {
+    setMock(mocks)
+
     const { container } = render(
       <TestProvider>
         <Page {...props} />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
 import { Provider } from 'react-redux'
 
 import store from '../src/data'
+import '../src/styles.css'
 
 const App = ({ Component, pageProps }) => (
   <Provider store={store}>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,40 @@
+import Document, {
+  Html,
+  Head,
+  Main,
+  NextScript,
+  DocumentContext,
+} from 'next/document'
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head>
+          <link rel="icon" href="/favicon.ico" />
+          {/* http://necolas.github.io/normalize.css/ */}
+          <link
+            rel="stylesheet"
+            href="https://unpkg.com/normalize.css@8.0.1/normalize.css"
+          />
+          {/* https://terminalcss.xyz/ */}
+          <link
+            rel="stylesheet"
+            href="https://unpkg.com/terminal.css@0.7.1/dist/terminal.min.css"
+          />
+        </Head>
+        <body className="terminal">
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/pages/exchange.tsx
+++ b/pages/exchange.tsx
@@ -1,12 +1,18 @@
 import fetchRates from '../src/apiClient/rates'
 import ExchangeForm from '../src/components/ExchangeForm'
 import { RatesData } from '../src/types'
+import NavBar from '../src/components/NavBar'
 
 interface Props {
   initialData: RatesData
 }
 const Exchange = ({ initialData }: Props) => (
-  <ExchangeForm initialData={initialData} />
+  <>
+    <NavBar />
+    <div className="container">
+      <ExchangeForm initialData={initialData} />
+    </div>
+  </>
 )
 
 // glue code!

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,24 @@
 import Link from 'next/link'
 
+import NavBar from '../src/components/NavBar'
+
 const Home = () => (
   <>
-    <h3>{'currency-exchange'}</h3>
-    <pre>
-      <Link href="https://github.com/sombreroEnPuntas/currency-exchange">
-        {'Check the code on github!'}
-      </Link>
-    </pre>
-    <Link href="/exchange">{'Exchange'}</Link>
+    <NavBar />
+    <div className="container">
+      <div className="borderless-box">
+        <p>
+          {'To try the exchange app, go to >> '}
+          <Link href="/exchange">{'Exchange'}</Link>
+        </p>
+        <p>
+          {'Check the code on >> '}
+          <Link href="https://github.com/sombreroEnPuntas/currency-exchange">
+            {'github!'}
+          </Link>
+        </p>
+      </div>
+    </div>
   </>
 )
 

--- a/src/components/ExchangeForm/__snapshots__/index.test.tsx.snap
+++ b/src/components/ExchangeForm/__snapshots__/index.test.tsx.snap
@@ -6,59 +6,134 @@ exports[`ExchangeForm Renders default state 1`] = `
     id="exchange"
     name="exchange"
   >
-    <label
-      for="from"
-    >
-      GBP
-    </label>
-    <input
-      id="from"
-      max="58.33"
-      min="0"
-      name="from"
-      required=""
-      step="0.01"
-      type="number"
-      value=""
-    />
-    <div>
-      You have £58.33
-    </div>
-    <label
-      for="to"
-    >
-      USD
-    </label>
-    <input
-      id="to"
-      max="25.51"
-      min="0"
-      name="to"
-      readonly=""
-      step="0.01"
-      tabindex="-1"
-      type="number"
-      value=""
-    />
-    <div>
-      You have $25.51
-    </div>
-    <pre>
-      <code>
-         
-      </code>
-    </pre>
-    <button
-      type="button"
-    >
-      Cancel
-    </button>
-    <button
-      type="submit"
-    >
-      Exchange
-    </button>
+    <fieldset>
+      <legend>
+        Pockets
+      </legend>
+      <div
+        class="form-group"
+      >
+        <span
+          style="display: inline-flex;"
+        >
+          <label
+            for="from"
+            style="text-transform: capitalize;"
+          >
+            from: 
+          </label>
+          <a
+            class="pocket-currency-option"
+            role="button"
+          >
+            EUR
+          </a>
+          <a
+            class="pocket-currency-option active"
+            role="button"
+          >
+            GBP
+          </a>
+          <a
+            class="pocket-currency-option"
+            role="button"
+          >
+            USD
+          </a>
+        </span>
+        <input
+          id="from"
+          inputmode="decimal"
+          max="58.33"
+          min="0"
+          name="from"
+          pattern="[\\\\d\\\\.]*"
+          required=""
+          step="0.01"
+          type="number"
+          value=""
+        />
+        <div>
+          You have £58.33
+        </div>
+      </div>
+      <div
+        class="form-group"
+      >
+        <span
+          style="display: inline-flex;"
+        >
+          <label
+            for="to"
+            style="text-transform: capitalize;"
+          >
+            to: 
+          </label>
+          <a
+            class="pocket-currency-option"
+            role="button"
+          >
+            EUR
+          </a>
+          <a
+            class="pocket-currency-option"
+            role="button"
+          >
+            GBP
+          </a>
+          <a
+            class="pocket-currency-option active"
+            role="button"
+          >
+            USD
+          </a>
+        </span>
+        <input
+          id="to"
+          inputmode="decimal"
+          max="25.51"
+          min="0"
+          name="to"
+          pattern="[\\\\d\\\\.]*"
+          readonly=""
+          step="0.01"
+          tabindex="-1"
+          type="number"
+          value=""
+        />
+        <div>
+          You have $25.51
+        </div>
+      </div>
+      <div
+        class="form-group"
+        style="display: flex; justify-content: right;"
+      >
+        <button
+          class="btn btn-ghost"
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          class="btn btn-default"
+          type="submit"
+        >
+          Exchange
+        </button>
+      </div>
+    </fieldset>
   </form>
+  <div
+    class="terminal-prompt borderless-box"
+  >
+    <span
+      class=""
+      style="white-space: pre-wrap;"
+    >
+       
+    </span>
+  </div>
 </div>
 `;
 
@@ -68,60 +143,136 @@ exports[`ExchangeForm Renders error state 1`] = `
     id="exchange"
     name="exchange"
   >
-    <label
-      for="from"
-    >
-      GBP
-    </label>
-    <input
-      disabled=""
-      id="from"
-      max="58.33"
-      min="0"
-      name="from"
-      required=""
-      step="0.01"
-      type="number"
-      value=""
-    />
-    <div>
-      You have £58.33
-    </div>
-    <label
-      for="to"
-    >
-      USD
-    </label>
-    <input
-      id="to"
-      max="25.51"
-      min="0"
-      name="to"
-      readonly=""
-      step="0.01"
-      tabindex="-1"
-      type="number"
-      value=""
-    />
-    <div>
-      You have $25.51
-    </div>
-    <pre>
-      <code>
-        rawr!
-      </code>
-    </pre>
-    <button
-      type="button"
-    >
-      Cancel
-    </button>
-    <button
-      disabled=""
-      type="submit"
-    >
-      Exchange
-    </button>
+    <fieldset>
+      <legend>
+        Pockets
+      </legend>
+      <div
+        class="form-group"
+      >
+        <span
+          style="display: inline-flex;"
+        >
+          <label
+            for="from"
+            style="text-transform: capitalize;"
+          >
+            from: 
+          </label>
+          <a
+            class="pocket-currency-option"
+            role="button"
+          >
+            EUR
+          </a>
+          <a
+            class="pocket-currency-option active"
+            role="button"
+          >
+            GBP
+          </a>
+          <a
+            class="pocket-currency-option"
+            role="button"
+          >
+            USD
+          </a>
+        </span>
+        <input
+          disabled=""
+          id="from"
+          inputmode="decimal"
+          max="58.33"
+          min="0"
+          name="from"
+          pattern="[\\\\d\\\\.]*"
+          required=""
+          step="0.01"
+          type="number"
+          value=""
+        />
+        <div>
+          You have £58.33
+        </div>
+      </div>
+      <div
+        class="form-group"
+      >
+        <span
+          style="display: inline-flex;"
+        >
+          <label
+            for="to"
+            style="text-transform: capitalize;"
+          >
+            to: 
+          </label>
+          <a
+            class="pocket-currency-option"
+            role="button"
+          >
+            EUR
+          </a>
+          <a
+            class="pocket-currency-option"
+            role="button"
+          >
+            GBP
+          </a>
+          <a
+            class="pocket-currency-option active"
+            role="button"
+          >
+            USD
+          </a>
+        </span>
+        <input
+          disabled=""
+          id="to"
+          inputmode="decimal"
+          max="25.51"
+          min="0"
+          name="to"
+          pattern="[\\\\d\\\\.]*"
+          readonly=""
+          step="0.01"
+          tabindex="-1"
+          type="number"
+          value=""
+        />
+        <div>
+          You have $25.51
+        </div>
+      </div>
+      <div
+        class="form-group"
+        style="display: flex; justify-content: right;"
+      >
+        <button
+          class="btn btn-ghost"
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          class="btn btn-default"
+          disabled=""
+          type="submit"
+        >
+          Exchange
+        </button>
+      </div>
+    </fieldset>
   </form>
+  <div
+    class="terminal-prompt borderless-box"
+  >
+    <span
+      class="terminal-alert-error"
+      style="white-space: pre-wrap;"
+    >
+      rawr!
+    </span>
+  </div>
 </div>
 `;

--- a/src/components/ExchangeForm/index.test.tsx
+++ b/src/components/ExchangeForm/index.test.tsx
@@ -21,13 +21,13 @@ const testFromPocket = pocketsMock.find(({ currency }) => currency === 'GBP')
 const testToPocket = pocketsMock.find(({ currency }) => currency === 'USD')
 
 // Mock data
-const setMock = ({ from, to, transaction, push, ratesData }) => {
+const setMock = ({ fromPocket, toPocket, transaction, push, ratesData }) => {
   ;(useRouter as jest.Mock).mockImplementation(() => ({
     push,
   }))
   ;(usePockets as jest.Mock).mockImplementation(() => ({
-    from,
-    to,
+    fromPocket,
+    toPocket,
     transaction,
   }))
   ;(useRates as jest.Mock).mockImplementation(() => ({
@@ -36,13 +36,13 @@ const setMock = ({ from, to, transaction, push, ratesData }) => {
 }
 
 const setup = ({
-  from = testFromPocket,
-  to = testToPocket,
+  fromPocket = testFromPocket,
+  toPocket = testToPocket,
   transaction = jest.fn(),
   push = jest.fn(),
   ratesData = ratesDataMock,
 } = {}) => {
-  setMock({ from, to, transaction, push, ratesData })
+  setMock({ fromPocket, toPocket, transaction, push, ratesData })
   const initialDataMock = ratesDataMock
 
   const utils = render(

--- a/src/components/ExchangeForm/index.tsx
+++ b/src/components/ExchangeForm/index.tsx
@@ -1,66 +1,28 @@
-import React, { useState } from 'react'
-import { useRouter } from 'next/router'
+import React from 'react'
 
-import usePockets from './usePockets'
-import useRates from './useRates'
 import Message from '../Message'
 import PocketExchangeInput from '../PocketInput'
 import useAutoFocus from '../../utils/useAutoFocus'
-import formatMoney from '../../utils/formatMoney'
-import { RatesData, Currency } from '../../types'
-
-const convert = (value: string, exchangeRate: number): string =>
-  formatMoney(parseFloat(value) * exchangeRate)
+import { RatesData } from '../../types'
+import useFormState from './useFormState'
 
 interface Props {
   initialData: RatesData
 }
 const ExchangeForm = ({ initialData }: Props) => {
   // form state
-  const [fromTarget, setFromTarget] = useState<Currency>('GBP')
-  const [toTarget, setToTarget] = useState<Currency>('USD')
-  const [fromValue, setFromValue] = useState('')
-  const [toValue, setToValue] = useState('')
-
-  // data
-  const { from, to, transaction } = usePockets({ fromTarget, toTarget })
   const {
-    ratesData: { rates, error },
-  } = useRates({ initialData })
-  const exchangeRate = rates ? rates[toTarget] / rates[fromTarget] : null
-
-  // navigation
-  const router = useRouter()
-
-  // CTAs
-  const handleSelectOption = (pocketType: string) => (option: Currency) => {
-    switch (pocketType) {
-      case 'from':
-        toTarget === option && setToTarget(fromTarget)
-        setFromTarget(option)
-        break
-      case 'to':
-        fromTarget === option && setFromTarget(toTarget)
-        setToTarget(option)
-        break
-    }
-
-    setToValue(convert(fromValue, exchangeRate))
-  }
-  const handleInputChange = ({
-    target: { value },
-  }: React.ChangeEvent<HTMLInputElement>) => {
-    setFromValue(value)
-    setToValue(convert(value, exchangeRate))
-  }
-  const handleCancel = () => {
-    router.push('/')
-  }
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-
-    transaction(fromValue, toTarget, exchangeRate)
-  }
+    error,
+    fromPocket,
+    fromValue,
+    handleCancel,
+    handleInputChange,
+    handleSelectOptionFrom,
+    handleSelectOptionTo,
+    handleSubmit,
+    toPocket,
+    toValue,
+  } = useFormState({ initialData })
 
   // cuz' react rendering, we need to focus programmatically
   const inputRef = useAutoFocus()
@@ -76,16 +38,16 @@ const ExchangeForm = ({ initialData }: Props) => {
             innerRef={inputRef}
             name="from"
             onChange={handleInputChange}
-            onSelectOption={handleSelectOption('from')}
-            pocket={from}
+            onSelectOption={handleSelectOptionFrom}
+            pocket={fromPocket}
             required
             value={fromValue}
           />
           <PocketExchangeInput
             disabled={!!error}
             name="to"
-            onSelectOption={handleSelectOption('to')}
-            pocket={to}
+            onSelectOption={handleSelectOptionTo}
+            pocket={toPocket}
             readOnly
             tabIndex={-1}
             value={toValue}

--- a/src/components/ExchangeForm/index.tsx
+++ b/src/components/ExchangeForm/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 
 import usePockets from './usePockets'
 import useRates from './useRates'
+import Message from '../Message'
 import PocketExchangeInput from '../PocketInput'
 import useAutoFocus from '../../utils/useAutoFocus'
 import formatMoney from '../../utils/formatMoney'
@@ -32,17 +33,20 @@ const ExchangeForm = ({ initialData }: Props) => {
   const router = useRouter()
 
   // CTAs
-  // TODO implement UI
-  // const handleFromTargetSelection = ({
-  //   target: { value },
-  // }: React.ChangeEvent<HTMLInputElement>) => {
-  //   setFromTarget(value)
-  // }
-  // const handleToTargetSelection = ({
-  //   target: { value },
-  // }: React.ChangeEvent<HTMLInputElement>) => {
-  //   setToTarget(value)
-  // }
+  const handleSelectOption = (pocketType: string) => (option: Currency) => {
+    switch (pocketType) {
+      case 'from':
+        toTarget === option && setToTarget(fromTarget)
+        setFromTarget(option)
+        break
+      case 'to':
+        fromTarget === option && setFromTarget(toTarget)
+        setToTarget(option)
+        break
+    }
+
+    setToValue(convert(fromValue, exchangeRate))
+  }
   const handleInputChange = ({
     target: { value },
   }: React.ChangeEvent<HTMLInputElement>) => {
@@ -55,41 +59,60 @@ const ExchangeForm = ({ initialData }: Props) => {
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
 
-    transaction(fromValue, toValue)
+    transaction(fromValue, toTarget, exchangeRate)
   }
 
   // cuz' react rendering, we need to focus programmatically
   const inputRef = useAutoFocus()
 
   return (
-    <form id="exchange" name="exchange" onSubmit={handleSubmit}>
-      <PocketExchangeInput
-        // autoFocus won't work reliably here
-        disabled={!!error}
-        innerRef={inputRef}
-        name="from"
-        onChange={handleInputChange}
-        pocket={from}
-        required
-        value={fromValue}
-      />
-      <PocketExchangeInput
-        name="to"
-        pocket={to}
-        readOnly
-        tabIndex={-1}
-        value={toValue}
-      />
-      <pre>
-        <code>{error || ' '}</code>
-      </pre>
-      <button onClick={handleCancel} type="button">
-        {'Cancel'}
-      </button>
-      <button disabled={!!error} type="submit">
-        {'Exchange'}
-      </button>
-    </form>
+    <>
+      <form id="exchange" name="exchange" onSubmit={handleSubmit}>
+        <fieldset>
+          <legend>Pockets</legend>
+          <PocketExchangeInput
+            // autoFocus won't work reliably here
+            disabled={!!error}
+            innerRef={inputRef}
+            name="from"
+            onChange={handleInputChange}
+            onSelectOption={handleSelectOption('from')}
+            pocket={from}
+            required
+            value={fromValue}
+          />
+          <PocketExchangeInput
+            disabled={!!error}
+            name="to"
+            onSelectOption={handleSelectOption('to')}
+            pocket={to}
+            readOnly
+            tabIndex={-1}
+            value={toValue}
+          />
+          <div
+            className="form-group"
+            style={{ display: 'flex', justifyContent: 'right' }}
+          >
+            <button
+              className="btn btn-ghost"
+              onClick={handleCancel}
+              type="button"
+            >
+              {'Cancel'}
+            </button>
+            <button
+              className="btn btn-default"
+              disabled={!!error}
+              type="submit"
+            >
+              {'Exchange'}
+            </button>
+          </div>
+        </fieldset>
+      </form>
+      <Message error={!!error} message={error} />
+    </>
   )
 }
 

--- a/src/components/ExchangeForm/useFormState.ts
+++ b/src/components/ExchangeForm/useFormState.ts
@@ -1,0 +1,79 @@
+import React, { useState } from 'react'
+import { useRouter } from 'next/router'
+
+import usePockets from './usePockets'
+import useRates from './useRates'
+import formatMoney from '../../utils/formatMoney'
+import { Currency, RatesData } from '../../types'
+
+const convert = (value: string, exchangeRate: number): string =>
+  formatMoney(parseFloat(value) * exchangeRate)
+
+interface Deps {
+  initialData: RatesData
+}
+const useFormState = ({ initialData }: Deps) => {
+  // local state
+  const [fromTarget, setFromTarget] = useState<Currency>('GBP')
+  const [toTarget, setToTarget] = useState<Currency>('USD')
+  const [fromValue, setFromValue] = useState('')
+  const [toValue, setToValue] = useState('')
+
+  // global state
+  const { fromPocket, toPocket, transaction } = usePockets({
+    fromTarget,
+    toTarget,
+  })
+
+  // data
+  const {
+    ratesData: { rates, error },
+  } = useRates({ initialData })
+  const exchangeRate = rates ? rates[toTarget] / rates[fromTarget] : null
+
+  // navigation
+  const router = useRouter()
+
+  // CTAs
+  const handleSelectOptionFrom = (option: Currency) => {
+    toTarget === option && setToTarget(fromTarget)
+    setFromTarget(option)
+
+    setToValue(convert(fromValue, exchangeRate))
+  }
+  const handleSelectOptionTo = (option: Currency) => {
+    fromTarget === option && setFromTarget(toTarget)
+    setToTarget(option)
+
+    setToValue(convert(fromValue, exchangeRate))
+  }
+  const handleInputChange = ({
+    target: { value },
+  }: React.ChangeEvent<HTMLInputElement>) => {
+    setFromValue(value)
+    setToValue(convert(value, exchangeRate))
+  }
+  const handleCancel = () => {
+    router.push('/')
+  }
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    transaction(fromValue, toTarget, exchangeRate)
+  }
+
+  return {
+    error,
+    fromPocket,
+    fromValue,
+    handleCancel,
+    handleInputChange,
+    handleSelectOptionFrom,
+    handleSelectOptionTo,
+    handleSubmit,
+    toPocket,
+    toValue,
+  }
+}
+
+export default useFormState

--- a/src/components/ExchangeForm/usePockets.test.ts
+++ b/src/components/ExchangeForm/usePockets.test.ts
@@ -32,10 +32,15 @@ describe('usePockets', () => {
   it(`processes a transaction`, async () => {
     const { result } = setup()
     const userInputValue = '23.50'
-    const convertedValue = '31.59'
+    const targetCurrency = 'USD'
+    const exchangeRate = 1.2976934796093424
 
     await act(async () => {
-      await result.current.transaction(userInputValue, convertedValue)
+      await result.current.transaction(
+        userInputValue,
+        targetCurrency,
+        exchangeRate
+      )
     })
 
     // removes money from GBP pocket
@@ -45,7 +50,7 @@ describe('usePockets', () => {
     })
     // adds money to USD pocket
     expect(result.current.to).toStrictEqual({
-      availableAmount: 57.1,
+      availableAmount: 56.01,
       currency: 'USD',
     })
   })

--- a/src/components/ExchangeForm/usePockets.test.ts
+++ b/src/components/ExchangeForm/usePockets.test.ts
@@ -25,8 +25,8 @@ describe('usePockets', () => {
   it(`gets initial values`, async () => {
     const { result } = setup()
 
-    expect(result.current.from).toStrictEqual(testFromPocket)
-    expect(result.current.to).toStrictEqual(testToPocket)
+    expect(result.current.fromPocket).toStrictEqual(testFromPocket)
+    expect(result.current.toPocket).toStrictEqual(testToPocket)
   })
 
   it(`processes a transaction`, async () => {
@@ -44,12 +44,12 @@ describe('usePockets', () => {
     })
 
     // removes money from GBP pocket
-    expect(result.current.from).toStrictEqual({
+    expect(result.current.fromPocket).toStrictEqual({
       availableAmount: 34.83,
       currency: 'GBP',
     })
     // adds money to USD pocket
-    expect(result.current.to).toStrictEqual({
+    expect(result.current.toPocket).toStrictEqual({
       availableAmount: 56.01,
       currency: 'USD',
     })

--- a/src/components/ExchangeForm/usePockets.ts
+++ b/src/components/ExchangeForm/usePockets.ts
@@ -11,8 +11,8 @@ interface Deps {
 const usePockets = ({ fromTarget, toTarget }: Deps) => {
   const dispatch = useDispatch()
 
-  const from: Pocket = useSelector(getPocketByCurrency(fromTarget))
-  const to: Pocket = useSelector(getPocketByCurrency(toTarget))
+  const fromPocket: Pocket = useSelector(getPocketByCurrency(fromTarget))
+  const toPocket: Pocket = useSelector(getPocketByCurrency(toTarget))
 
   // NOTE: IRL this should be a BE action, otherwise it could be abused.
   // Request should include a timestamp to ensure we give the same
@@ -25,7 +25,7 @@ const usePockets = ({ fromTarget, toTarget }: Deps) => {
     dispatch(
       setPocketByCurrency({
         availableAmount: roundToTwoDecimals(
-          from.availableAmount - parseFloat(fromValue)
+          fromPocket.availableAmount - parseFloat(fromValue)
         ),
         currency: fromTarget,
       })
@@ -33,14 +33,14 @@ const usePockets = ({ fromTarget, toTarget }: Deps) => {
     dispatch(
       setPocketByCurrency({
         availableAmount: roundToTwoDecimals(
-          parseFloat(fromValue) * exchangeRate + to.availableAmount
+          parseFloat(fromValue) * exchangeRate + toPocket.availableAmount
         ),
         currency,
       })
     )
   }
 
-  return { from, to, transaction }
+  return { fromPocket, toPocket, transaction }
 }
 
 export default usePockets

--- a/src/components/ExchangeForm/useRates.ts
+++ b/src/components/ExchangeForm/useRates.ts
@@ -15,12 +15,18 @@ const useRates = ({ initialData }: Deps) => {
       // setInterval will result on clashing requests
       // if response time is longer than 10 sec
       timeoutID = setTimeout(async () => {
-        const data: RatesData = await fetch(`api/rates`).then((res) =>
-          res.json()
-        )
+        let data: RatesData = null
+        try {
+          data = await fetch(`api/rates`).then((res) => res.json())
+        } catch (e) {
+          data = {
+            error: `${e.message}`,
+            rates: null,
+          }
+        }
         setRatesData(data)
 
-        pollEveryTenSeconds()
+        if (!data.error) pollEveryTenSeconds()
       }, 10_000)
     }
 
@@ -29,7 +35,7 @@ const useRates = ({ initialData }: Deps) => {
     return () => {
       clearTimeout(timeoutID)
     }
-  })
+  }, [])
 
   return { ratesData }
 }

--- a/src/components/Message/index.tsx
+++ b/src/components/Message/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+interface Props {
+  error?: boolean
+  message: string
+}
+const Message = ({ error, message }: Props) => (
+  <div className="terminal-prompt borderless-box">
+    <span
+      className={error ? 'terminal-alert-error' : ''}
+      style={{
+        whiteSpace: 'pre-wrap',
+      }}
+    >
+      {message || ' '}
+    </span>
+  </div>
+)
+
+export default Message

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+const pages = [
+  { href: '/exchange', label: 'Exchange' },
+  { href: '/', label: 'About' },
+]
+
+const NavLink = ({ href, label }) => {
+  const router = useRouter()
+
+  return (
+    <li>
+      <Link href={href}>
+        <a className={`menu-item${router.pathname === href ? ' active' : ''}`}>
+          {label}
+        </a>
+      </Link>
+    </li>
+  )
+}
+
+const NavBar = () => (
+  <div className="terminal-nav header">
+    <div className="terminal-logo">
+      <div className="logo terminal-prompt">
+        <a href="#" className="no-style">
+          {'currency-exchange'}
+        </a>
+      </div>
+    </div>
+    <nav className="terminal-menu">
+      <ul>
+        {pages.map((page) => (
+          <NavLink key={`menu-item-${page.label}`} {...page} />
+        ))}
+      </ul>
+    </nav>
+  </div>
+)
+
+export default NavBar

--- a/src/components/PocketInput/__snapshots__/index.test.tsx.snap
+++ b/src/components/PocketInput/__snapshots__/index.test.tsx.snap
@@ -2,21 +2,50 @@
 
 exports[`PocketInput Renders mandatory data 1`] = `
 <div>
-  <label
-    for="from"
+  <div
+    class="form-group"
   >
-    GBP
-  </label>
-  <input
-    id="from"
-    max="58.33"
-    min="0"
-    name="from"
-    step="0.01"
-    type="number"
-  />
-  <div>
-    You have £58.33
+    <span
+      style="display: inline-flex;"
+    >
+      <label
+        for="from"
+        style="text-transform: capitalize;"
+      >
+        from: 
+      </label>
+      <a
+        class="pocket-currency-option"
+        role="button"
+      >
+        EUR
+      </a>
+      <a
+        class="pocket-currency-option active"
+        role="button"
+      >
+        GBP
+      </a>
+      <a
+        class="pocket-currency-option"
+        role="button"
+      >
+        USD
+      </a>
+    </span>
+    <input
+      id="from"
+      inputmode="decimal"
+      max="58.33"
+      min="0"
+      name="from"
+      pattern="[\\\\d\\\\.]*"
+      step="0.01"
+      type="number"
+    />
+    <div>
+      You have £58.33
+    </div>
   </div>
 </div>
 `;

--- a/src/components/PocketInput/index.test.tsx
+++ b/src/components/PocketInput/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 
 // Tested Unit
 import Component from '.'
@@ -13,24 +13,32 @@ const testPocket = pocketsMock.find(({ currency }) => currency === 'GBP')
 // Mock data
 const getProps = (customProps) => ({
   name: 'from',
+  onSelectOption: jest.fn(),
   pocket: testPocket,
   ...customProps,
 })
 
 const setup = (customProps = {}) => {
   const utils = render(<Component {...getProps(customProps)} />)
-  const inputEl = utils.getByLabelText('GBP')
+  const inputEl = utils.getByLabelText('from:')
+  const EUR = utils.getByText(/EUR/)
+  const GBP = utils.getByText(/GBP/)
+  const USD = utils.getByText(/USD/)
 
-  return { inputEl, ...utils }
+  return { inputEl, EUR, GBP, USD, ...utils }
 }
 
 describe('PocketInput', () => {
   it('Renders mandatory data', () => {
-    const { container, getByText, inputEl } = setup()
+    const { container, getByText, inputEl, EUR, GBP, USD } = setup()
 
     expect(inputEl).toHaveAttribute('id', 'from')
     expect(inputEl).toHaveAttribute('name', 'from')
     expect(inputEl).toHaveAttribute('type', 'number')
+
+    expect(EUR).not.toHaveClass('active')
+    expect(GBP).toHaveClass('active')
+    expect(USD).not.toHaveClass('active')
 
     expect(getByText(/You have £58.33/)).toBeVisible()
 
@@ -41,5 +49,14 @@ describe('PocketInput', () => {
     const { inputEl } = setup({ required: true })
 
     expect(inputEl).toHaveAttribute('required')
+  })
+
+  it('Handles currency selection', () => {
+    const handleSelect = jest.fn()
+    const { EUR } = setup({ onSelectOption: handleSelect })
+
+    fireEvent.click(EUR)
+
+    expect(handleSelect).toHaveBeenCalledWith('EUR')
   })
 })

--- a/src/components/PocketInput/index.tsx
+++ b/src/components/PocketInput/index.tsx
@@ -1,28 +1,53 @@
 import React from 'react'
 
 import formatMoney from '../../utils/formatMoney'
-import { Pocket } from '../../types'
+import { Pocket, Currency } from '../../types'
+import config from '../../utils/config'
 
 // NOTE: Input validation is done via HTML attrs.
 // Maybe use something more flexible like `yup` IRL :)
 interface Props extends React.HTMLProps<HTMLInputElement> {
   innerRef?: React.MutableRefObject<HTMLInputElement>
   name: string
+  onSelectOption: React.Dispatch<React.SetStateAction<Currency>>
   pocket: Pocket
 }
 const PocketExchangeInput = ({
   innerRef,
   name,
+  onSelectOption,
   pocket,
   ...inputProps
 }: Props) => (
-  <>
-    <label htmlFor={name}>{pocket.currency}</label>
+  <div className="form-group">
+    <span
+      style={{
+        display: 'inline-flex',
+      }}
+    >
+      <label style={{ textTransform: 'capitalize' }} htmlFor={name}>
+        {`${name}: `}
+      </label>
+      {config.availableCurrencies.map((currency: Currency) => (
+        <a
+          onClick={() => onSelectOption(currency)}
+          role="button"
+          key={currency}
+          className={`pocket-currency-option${
+            pocket.currency === currency ? ' active' : ''
+          }`}
+        >
+          {currency}
+        </a>
+      ))}
+    </span>
     <input
       id={name}
+      inputMode="decimal"
       max={formatMoney(pocket.availableAmount)}
       min="0"
       name={name}
+      pattern="[\d\.]*"
       ref={innerRef}
       step="0.01"
       type="number"
@@ -32,7 +57,7 @@ const PocketExchangeInput = ({
       pocket.availableAmount,
       pocket.currency
     )}`}</div>
-  </>
+  </div>
 )
 
 export default PocketExchangeInput

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,36 @@
+button:disabled,
+input:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+.borderless-box {
+  border: 1px solid transparent;
+  margin: 2px;
+  padding: 1em;
+  width: calc(100% - 4px);
+}
+
+.header {
+  background-color: var(--background-color);
+  border: 1px solid var(--secondary-color);
+  position: sticky;
+  top: 0;
+  left: 0;
+  right: 0;
+  padding: 0 1em;
+}
+
+.pocket-currency-option {
+  text-decoration: none;
+  display: block;
+  width: 100%;
+  border: none;
+  color: var(--secondary-color);
+  margin: 0 0.25em;
+}
+
+.pocket-currency-option.active {
+  color: var(--font-color);
+  text-decoration: underline;
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,3 +1,4 @@
 export default {
   exchangeRateAPIRoute: 'https://openexchangerates.org/api/latest.json',
+  availableCurrencies: ['EUR', 'GBP', 'USD'],
 }

--- a/src/utils/formatMoney.ts
+++ b/src/utils/formatMoney.ts
@@ -1,6 +1,6 @@
 import { Currency } from '../types'
 
-const roundToTwoDecimals = (number: number) =>
+export const roundToTwoDecimals = (number: number) =>
   Math.round((number + Number.EPSILON) * 100) / 100
 
 const localFormatter = (currency?: Currency) =>


### PR DESCRIPTION
Allow users to select which `Pocket`s to use when requesting an exchange
transaction.
Implement styles keeping a serious, sober and trustworthy look and feel.
TODO:
 - [x] implement fancy UI
 - [x] allow changing target pockets
 - [ ] keep tx hiostory
 - [x] consume exchange data from API

Uses: [normalize.css](http://necolas.github.io/normalize.css/) and
[terminal.css](https://terminalcss.xyz/)